### PR TITLE
Add see all conversations feature

### DIFF
--- a/app/controllers/api/v1/matches_controller.rb
+++ b/app/controllers/api/v1/matches_controller.rb
@@ -1,0 +1,19 @@
+module Api
+  module V1
+    class MatchesController < ApiController
+      def index
+        @matches = Match.user_matches(current_user)
+      end
+
+      def show
+        match
+      end
+
+      private
+
+      def match
+        @match ||= Match.user_matches(current_user).find(params[:id])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/matches_controller.rb
+++ b/app/controllers/api/v1/matches_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class MatchesController < ApiController
+      helper_method :match
+
       def index
         @matches = Match.user_matches(current_user)
       end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -40,6 +40,11 @@ class Match < ApplicationRecord
             .or(Match.distinct.where(user_compatible_id: target.user.id))
         }
 
+  scope :user_matches, lambda { |user|
+    where(user_creator_id: user.id)
+      .or(Match.where(user_compatible_id: user.id))
+  }
+
   private
 
   def create_conversation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,12 +46,12 @@ class User < ApplicationRecord
   has_many :targets, dependent: :destroy
   has_many :messages, dependent: :destroy
   has_many :matches_creator,
-           foreign_key: :match_creator,
+           foreign_key: :user_creator,
            class_name: 'Match',
            dependent: :destroy,
            inverse_of: :target_creator
   has_many :matches_compatible,
-           foreign_key: :match_compatible,
+           foreign_key: :user_compatible,
            class_name: 'Match',
            dependent: :destroy,
            inverse_of: :target_compatible

--- a/app/views/api/v1/matches/_info.json.jbuilder
+++ b/app/views/api/v1/matches/_info.json.jbuilder
@@ -1,0 +1,6 @@
+json.id                   match.id
+json.target_creator_id    match.target_creator_id
+json.target_compatible_id match.target_compatible_id
+json.user_creator_id      match.user_creator_id
+json.user_compatible_id   match.user_compatible_id
+json.conversation_id      match.conversation_id

--- a/app/views/api/v1/matches/index.json.jbuilder
+++ b/app/views/api/v1/matches/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.matches @matches, partial: 'info', as: :match

--- a/app/views/api/v1/matches/show.json.jbuilder
+++ b/app/views/api/v1/matches/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.match @match, partial: 'info', as: :match

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
       resources :users, only: %i[index show], format: 'json'
       resources :topics, only: %i[index show], format: 'json'
       resources :targets, only: %i[index show create destroy]
+      resources :matches, only: %i[index show]
       get :status, to: 'api#status'
     end
   end

--- a/spec/requests/matches/index_matches_spec.rb
+++ b/spec/requests/matches/index_matches_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe 'GET /api/v1/matches', type: :request do
+  let!(:user_1)   { create :user }
+  let!(:user_2) { create :user }
+  let!(:target_1) { create :target, user: user_1 }
+  let!(:targets_2) do
+    create_list :target,
+                3,
+                radius: target_1.radius,
+                latitude: target_1.latitude,
+                longitude: target_1.longitude,
+                topic_id: target_1.topic.id,
+                user: user_2
+  end
+
+  context 'with signed-out user' do
+    subject { get api_v1_matches_path, as: :json }
+
+    it 'returns unauthorized' do
+      subject
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns error message' do
+      subject
+      json = parsed_response
+      expect(json).to include_json(errors: ['You need to sign in or sign up before continuing.'])
+    end
+  end
+
+  context 'with signed-in user' do
+    let(:headers) { auth_headers(user_2) }
+    subject { get api_v1_matches_path, headers: headers, as: :json }
+
+    it 'returns a success status' do
+      subject
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'returns an array of matches' do
+      subject
+      matches_arr = targets_2.map do |target|
+        {
+          target_creator_id: target.id,
+          target_compatible_id: target_1.id,
+          user_creator_id: user_2.id,
+          user_compatible_id: user_1.id
+        }
+      end
+      expect(parsed_response).to include_json(matches: matches_arr)
+    end
+  end
+end

--- a/spec/requests/matches/show_matches_spec.rb
+++ b/spec/requests/matches/show_matches_spec.rb
@@ -12,9 +12,11 @@ describe 'GET /api/v1/matches/:id', type: :request do
            topic_id: target_1.topic.id,
            user: user_2
   end
+  subject { get api_v1_match_path(match_id), headers: headers, as: :json }
 
   context 'with signed-out user' do
-    subject { get api_v1_match_path(target_2.matches_creators.last), as: :json }
+    let!(:headers) { {} }
+    let!(:match_id) { target_2.matches_creators.last }
 
     it 'returns unauthorized' do
       subject
@@ -29,10 +31,10 @@ describe 'GET /api/v1/matches/:id', type: :request do
   end
 
   context 'with signed-in user' do
-    let(:headers) { auth_headers(user_2) }
+    let!(:headers) { auth_headers(user_2) }
 
     context 'with invalid match id' do
-      subject { get api_v1_match_path('invalid_match_id!'), headers: headers, as: :json }
+      let!(:match_id) { 'invalid_match_id!' }
 
       it 'returns a not found status' do
         subject
@@ -46,7 +48,7 @@ describe 'GET /api/v1/matches/:id', type: :request do
     end
 
     context 'with valid match id' do
-      subject { get api_v1_match_path(target_2.matches_creators.last), headers: headers, as: :json }
+      let!(:match_id) { target_2.matches_creators.last }
 
       it 'returns a success status' do
         subject

--- a/spec/requests/matches/show_matches_spec.rb
+++ b/spec/requests/matches/show_matches_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe 'GET /api/v1/matches/:id', type: :request do
+  let!(:user_1)   { create :user }
+  let!(:user_2) { create :user }
+  let!(:target_1) { create :target, user: user_1 }
+  let!(:target_2) do
+    create :target,
+           radius: target_1.radius,
+           latitude: target_1.latitude,
+           longitude: target_1.longitude,
+           topic_id: target_1.topic.id,
+           user: user_2
+  end
+
+  context 'with signed-out user' do
+    subject { get api_v1_match_path(target_2.matches_creators.last), as: :json }
+
+    it 'returns unauthorized' do
+      subject
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns error message' do
+      subject
+      json = parsed_response
+      expect(json).to include_json(errors: ['You need to sign in or sign up before continuing.'])
+    end
+  end
+
+  context 'with signed-in user' do
+    let(:headers) { auth_headers(user_2) }
+
+    context 'with invalid match id' do
+      subject { get api_v1_match_path('invalid_match_id!'), headers: headers, as: :json }
+
+      it 'returns a not found status' do
+        subject
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'returns an error message' do
+        subject
+        expect(parsed_response).to include_json(error: 'Couldn\'t find the record')
+      end
+    end
+
+    context 'with valid match id' do
+      subject { get api_v1_match_path(target_2.matches_creators.last), headers: headers, as: :json }
+
+      it 'returns a success status' do
+        subject
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns the match' do
+        subject
+        match = {
+          target_creator_id: target_2.id,
+          target_compatible_id: target_1.id,
+          user_creator_id: user_2.id,
+          user_compatible_id: user_1.id
+        }
+        expect(parsed_response).to include_json(match: match)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Te endpoint is _matches_ and not _conversations_ because, the conversations model contains only an id. The id alone doesn't tell us much about the conversation itself. However the match object contains both targets, both users and the conversation id.

[Trello card](https://trello.com/c/SCb2PfRY)